### PR TITLE
Fix remove old version

### DIFF
--- a/src/Versionable.php
+++ b/src/Versionable.php
@@ -88,7 +88,7 @@ trait Versionable
             return;
         }
 
-        $this->versions()->skip($keep)->take($keep)->get()->each->delete();
+        $this->versions()->skip($keep)->take(PHP_INT_MAX)->get()->each->delete();
     }
 
     public function removeAllVersions()


### PR DESCRIPTION
You will never delete all versions if take($keep) it's used.

 I change to ->take(PHP_INT_MAX) so that it take all records apart first that is skipped.

I didn't find a better solution to set limit to "all records".

The issue happen if you change keep max versions after already exist some versions.

For example you start with max 10, and then you change to max 3, then you will never delete older versions that was already saved before change config.

I hope that I explain well myself.