### PR TITLE
Fix double slashes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ $ composer require overtrue/laravel-versionable -vvv
 Optional, you can publish the config file:
 
 ```bash
-$ php artisan vendor:publish --provider="Overtrue\\LaravelVersionable\\ServiceProvider" --tag=config
+$ php artisan vendor:publish --provider="Overtrue\LaravelVersionable\ServiceProvider" --tag=config
 ```
 
 And if you want to custom the migration of the versions table, you can publish the migration file to your database path:
 
 ```bash
-$ php artisan vendor:publish --provider="Overtrue\\LaravelVersionable\\ServiceProvider" --tag=migrations
+$ php artisan vendor:publish --provider="Overtrue\LaravelVersionable\ServiceProvider" --tag=migrations
 ```
 
 Then run this command to create a database migration:


### PR DESCRIPTION
Fix "Unable to locate publishable resources." error when trying to publish config or migrations.