### PR TITLE
fix type

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -18,7 +18,7 @@ class Version extends Model
     /**
      * @var array
      */
-    protected $casts = [
+    protected array $casts = [
         'contents' => 'array',
     ];
 


### PR DESCRIPTION
fix Type of Overtrue\LaravelVersionable\Version::$casts must be array (as in class Illuminate\Database\Eloquent\Model)