### PR TITLE
Using passthrough of model connection.

### DIFF
--- a/config/versionable.php
+++ b/config/versionable.php
@@ -27,4 +27,9 @@ return [
      * The model class for user.
      */
     'user_model' => \App\Models\User::class,
+    
+    /**
+    * The databases to migrate versions table to.
+    */
+    'databases' => [],
 ];

--- a/config/versionable.php
+++ b/config/versionable.php
@@ -27,9 +27,4 @@ return [
      * The model class for user.
      */
     'user_model' => \App\Models\User::class,
-    
-    /**
-    * The databases to migrate versions table to.
-    */
-    'databases' => [],
 ];

--- a/src/Version.php
+++ b/src/Version.php
@@ -57,8 +57,10 @@ class Version extends Model
     {
         /* @var \Overtrue\LaravelVersionable\Versionable|Model $model */
         $versionClass = $model->getVersionModel();
+        $versionConnection = $model->getConnectionName();
 
         $version = new $versionClass();
+        $version->setConnection($versionConnection);
 
         $version->versionable_id = $model->getKey();
         $version->versionable_type = $model->getMorphClass();


### PR DESCRIPTION
Code change for #36.

This will allow for multiple database connections where the connection from the model with the versionable trait will pass through to the version model.

It does require that the version table exists in any database with a table that is versionable but that is the intent of this change.

When there is no connection specied (ie: null connection name) Laravel will just use the default connection.