### PR TITLE
Allow adding versions manually

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -71,7 +71,9 @@ class Version extends Model
         $version->{\config('versionable.user_foreign_key')} = $model->getVersionUserId();
         $version->contents = $model->getVersionableAttributes($attributes);
 
-        if ($time) $version->created_at = Carbon::parse($time);
+        if ($time) { 
+            $version->created_at = Carbon::parse($time);
+        }
 
         $version->save();
 

--- a/src/Version.php
+++ b/src/Version.php
@@ -2,8 +2,10 @@
 
 namespace Overtrue\LaravelVersionable;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
 /**
  * @property Model|\Overtrue\LaravelVersionable\Versionable $versionable
@@ -50,9 +52,12 @@ class Version extends Model
     /**
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  array  $attributes
+     * @param  string|DateTimeInterface|null  $time
      * @return \Overtrue\LaravelVersionable\Version
+     *
+     * @throws \Carbon\Exceptions\InvalidFormatException
      */
-    public static function createForModel(Model $model, array $attributes = []): Version
+    public static function createForModel(Model $model, array $attributes = [], $time = null): Version
     {
         /* @var \Overtrue\LaravelVersionable\Versionable|Model $model */
         $versionClass = $model->getVersionModel();
@@ -64,7 +69,9 @@ class Version extends Model
         $version->versionable_id = $model->getKey();
         $version->versionable_type = $model->getMorphClass();
         $version->{\config('versionable.user_foreign_key')} = $model->getVersionUserId();
-        $version->contents = \array_merge($attributes, $model->getVersionableAttributes());
+        $version->contents = \array_merge($model->getVersionableAttributes(), $attributes);
+
+        if ($time) $version->created_at = Carbon::parse($time);
 
         $version->save();
 
@@ -81,19 +88,46 @@ class Version extends Model
         return $this->versionable->forceFill($this->contents);
     }
 
+    public function scopeOrderOldestFirst(Builder $query): Builder
+    {
+        return $query->oldest()->oldest('id');
+    }
+
+    public function scopeOrderLatestFirst(Builder $query): Builder
+    {
+        return $query->latest()->latest('id');
+    }
+
     public function previousVersion(): ?static
     {
-        return $this->versionable->versions()->where('id', '<', $this->id)->latest('id')->first();
+        return $this->versionable->history()
+            ->where(function ($query) {
+                $query->where('created_at', '<', $this->created_at)
+                    ->orWhere(function ($query) {
+                        $query->where('id', '<', $this->getKey())
+                            ->where('created_at', '<=', $this->created_at);
+                    });
+            })
+            ->first();
     }
 
     public function nextVersion(): ?static
     {
-        return $this->versionable->versions()->where('id', '>', $this->id)->oldest('id')->first();
+        return $this->versionable->versions()
+            ->where(function ($query) {
+                $query->where('created_at', '>', $this->created_at)
+                    ->orWhere(function ($query) {
+                        $query->where('id', '>', $this->getKey())
+                            ->where('created_at', '>=', $this->created_at);
+                    });
+            })
+            ->orderOldestFirst()
+            ->first();
     }
 
     public function diff(Version $toVersion = null, array $differOptions = [], array $renderOptions = []): Diff
     {
-        if (! $toVersion) {
+        if (!$toVersion) {
             $toVersion = $this->previousVersion() ?? new static();
         }
 

--- a/src/Version.php
+++ b/src/Version.php
@@ -69,7 +69,7 @@ class Version extends Model
         $version->versionable_id = $model->getKey();
         $version->versionable_type = $model->getMorphClass();
         $version->{\config('versionable.user_foreign_key')} = $model->getVersionUserId();
-        $version->contents = \array_merge($model->getVersionableAttributes(), $attributes);
+        $version->contents = $model->getVersionableAttributes($attributes);
 
         if ($time) $version->created_at = Carbon::parse($time);
 

--- a/src/Versionable.php
+++ b/src/Versionable.php
@@ -181,23 +181,23 @@ trait Versionable
         return !empty($this->getVersionableAttributes());
     }
 
-    public function getVersionableAttributes(): array
+    public function getVersionableAttributes(array $attributes = []): array
     {
         $changes = $this->getDirty();
 
-        if (empty($changes)) {
+        if (empty($changes) && empty($attributes)) {
             return [];
         }
 
         $changes = $this->versionableFromArray($changes);
         $changedKeys = array_keys($changes);
 
-        if ($this->getVersionStrategy() === VersionStrategy::SNAPSHOT && !empty($changes)) {
+        if ($this->getVersionStrategy() === VersionStrategy::SNAPSHOT && (!empty($changes) || !empty($attributes))) {
             $changedKeys = array_keys($this->getAttributes());
         }
 
         // to keep casts and mutators works, we need to get the updated attributes from the model
-        return $this->only($changedKeys);
+        return \array_merge($this->only($changedKeys), $attributes);
     }
 
     /**

--- a/src/Versionable.php
+++ b/src/Versionable.php
@@ -21,7 +21,7 @@ trait Versionable
     {
         static::saved(
             function (Model $model) {
-                static::createVersionForModel($model);
+                $model->autoCreateVersion();
             }
         );
 
@@ -31,24 +31,47 @@ trait Versionable
                 if ($model->forceDeleting) {
                     $model->forceRemoveAllVersions();
                 } else {
-                    static::createVersionForModel($model);
+                    $model->autoCreateVersion();
                 }
             }
         );
     }
 
-    private static function createVersionForModel(Model $model): void
+    private function autoCreateVersion(): ?Version
     {
-        /* @var \Overtrue\LaravelVersionable\Versionable|Model $model */
-        if (static::$versioning && $model->shouldVersioning()) {
-            Version::createForModel($model);
-            $model->removeOldVersions($model->getKeepVersionsCount());
+        if (static::$versioning) {
+            return $this->createVersion();
         }
+
+        return null;
+    }
+
+    /**
+     * @param  array  $attributes
+     * @param  string|DateTimeInterface|null  $time
+     * @return ?Version
+     *
+     * @throws \Carbon\Exceptions\InvalidFormatException
+     */
+    public function createVersion(array $attributes = [], $time = null): ?Version
+    {
+        if ($this->shouldBeVersioning() || !empty($attributes)) {
+            return tap(Version::createForModel($this, $attributes, $time), function () {
+                $this->removeOldVersions($this->getKeepVersionsCount());
+            });
+        }
+
+        return null;
     }
 
     public function versions(): MorphMany
     {
         return $this->morphMany($this->getVersionModel(), 'versionable');
+    }
+
+    public function history(): MorphMany
+    {
+        return $this->versions()->orderLatestFirst();
     }
 
     public function lastVersion(): MorphOne
@@ -58,12 +81,12 @@ trait Versionable
 
     public function latestVersion(): MorphOne
     {
-        return $this->morphOne($this->getVersionModel(), 'versionable')->latest('id');
+        return $this->morphOne($this->getVersionModel(), 'versionable')->orderLatestFirst();
     }
 
     public function firstVersion(): MorphOne
     {
-        return $this->morphOne($this->getVersionModel(), 'versionable')->oldest('id');
+        return $this->morphOne($this->getVersionModel(), 'versionable')->orderOldestFirst();
     }
 
     /**
@@ -77,10 +100,8 @@ trait Versionable
      */
     public function versionAt($time = null, $tz = null): ?Version
     {
-        return $this->versions()
+        return $this->history()
             ->where('created_at', '<=', Carbon::parse($time, $tz))
-            ->orderByDesc('created_at')
-            ->orderByDesc($this->getKey())
             ->first();
     }
 
@@ -110,7 +131,7 @@ trait Versionable
             return;
         }
 
-        $this->versions()->skip($keep)->take(PHP_INT_MAX)->get()->each->delete();
+        $this->history()->skip($keep)->take(PHP_INT_MAX)->get()->each->delete();
     }
 
     public function removeVersions(array $ids)
@@ -155,9 +176,9 @@ trait Versionable
         $this->versions->each->forceDelete();
     }
 
-    public function shouldVersioning(): bool
+    public function shouldBeVersioning(): bool
     {
-        return ! empty($this->getVersionableAttributes());
+        return !empty($this->getVersionableAttributes());
     }
 
     public function getVersionableAttributes(): array
@@ -171,7 +192,7 @@ trait Versionable
         $changes = $this->versionableFromArray($changes);
         $changedKeys = array_keys($changes);
 
-        if ($this->getVersionStrategy() === VersionStrategy::SNAPSHOT && ! empty($changes)) {
+        if ($this->getVersionStrategy() === VersionStrategy::SNAPSHOT && !empty($changes)) {
             $changedKeys = array_keys($this->getAttributes());
         }
 
@@ -184,7 +205,7 @@ trait Versionable
      */
     public function setVersionable(array $attributes): static
     {
-        if (! \property_exists($this, 'versionable')) {
+        if (!\property_exists($this, 'versionable')) {
             throw new \Exception('Property $versionable not exist.');
         }
 
@@ -198,7 +219,7 @@ trait Versionable
      */
     public function setDontVersionable(array $attributes): static
     {
-        if (! \property_exists($this, 'dontVersionable')) {
+        if (!\property_exists($this, 'dontVersionable')) {
             throw new \Exception('Property $dontVersionable not exist.');
         }
 
@@ -227,7 +248,7 @@ trait Versionable
      */
     public function setVersionStrategy(string $strategy): static
     {
-        if (! \property_exists($this, 'versionStrategy')) {
+        if (!\property_exists($this, 'versionStrategy')) {
             throw new \Exception('Property $versionStrategy not exist.');
         }
 

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -291,70 +291,6 @@ class FeatureTest extends TestCase
     /**
      * @test
      */
-    public function user_can_create_versions_manually()
-    {
-        $post = Post::create(['title' => 'version1', 'content' => 'version1 content']);
-        $post->setVersionStrategy(VersionStrategy::SNAPSHOT);
-
-        $this->assertCount(1, $post->refresh()->versions);
-        $this->assertEquals('version1', $post->latestVersion->contents['title']);
-
-        $post->title = 'version2';
-
-        $this->assertNotNull($post->createVersion());
-        $this->assertCount(2, $post->refresh()->versions);
-        $this->assertEquals('version2', $post->latestVersion->contents['title']);
-
-        $post->title = 'version3';
-
-        $this->assertNotNull($post->createVersion());
-        $this->assertCount(3, $post->refresh()->versions);
-        $this->assertEquals('version3', $post->latestVersion->contents['title']);
-    }
-
-    /**
-     * @test
-     */
-    public function user_cannot_create_versions_manually_without_changes()
-    {
-        $post = Post::create(['title' => 'version1', 'content' => 'version1 content']);
-        $post->setVersionStrategy(VersionStrategy::SNAPSHOT);
-
-        $this->assertCount(1, $post->refresh()->versions);
-        $this->assertEquals('version1', $post->latestVersion->contents['title']);
-
-        $this->assertNull($post->createVersion());
-        $this->assertNull($post->createVersion());
-        $this->assertNull($post->createVersion());
-
-        $this->assertCount(1, $post->refresh()->versions);
-    }
-
-    /**
-     * @test
-     */
-    public function user_cannot_create_versions_manually_by_passing_attributes()
-    {
-        $post = Post::create(['title' => 'version1', 'content' => 'version1 content']);
-        $post->setVersionStrategy(VersionStrategy::SNAPSHOT);
-
-        $this->assertCount(1, $post->refresh()->versions);
-        $this->assertEquals('version1', $post->latestVersion->contents['title']);
-
-        $this->assertNull($post->createVersion());
-
-        $this->assertNotNull($post->createVersion(['title' => 'version2']));
-        $this->assertCount(2, $post->refresh()->versions);
-        $this->assertEquals('version2', $post->latestVersion->contents['title']);
-
-        $this->assertNotNull($post->createVersion(['title' => 'version3']));
-        $this->assertCount(3, $post->refresh()->versions);
-        $this->assertEquals('version3', $post->latestVersion->contents['title']);
-    }
-
-    /**
-     * @test
-     */
     public function post_version_soft_delete_and_restore()
     {
         $post = Post::create(['title' => 'version1', 'content' => 'version1 content']);
@@ -455,6 +391,4 @@ class FeatureTest extends TestCase
 
         $this->assertArrayNotHasKey('user', $post->latestVersion->contents);
     }
-
-
 }

--- a/tests/ManualVersionTest.php
+++ b/tests/ManualVersionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Carbon;
+use Overtrue\LaravelVersionable\VersionStrategy;
+
+class ManualVersionTest extends TestCase
+{
+    protected $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Post::enableVersioning();
+
+        config([
+            'auth.providers.users.model' => User::class,
+            'versionable.user_model' => User::class,
+        ]);
+
+        $this->user = User::create(['name' => 'marijoo']);
+        $this->actingAs($this->user);
+    }
+
+    /**
+     * @test
+     */
+    public function user_can_create_versions_manually()
+    {
+        $post = Post::create(['title' => 'version1', 'content' => 'version1 content']);
+
+        $this->assertCount(1, $post->refresh()->versions);
+        $this->assertEquals('version1', $post->latestVersion->contents['title']);
+
+        $post->title = 'version2';
+
+        $this->assertNotNull($post->createVersion());
+        $this->assertCount(2, $post->refresh()->versions);
+        $this->assertEquals('version2', $post->latestVersion->contents['title']);
+
+        $post->title = 'version3';
+
+        $this->assertNotNull($post->createVersion());
+        $this->assertCount(3, $post->refresh()->versions);
+        $this->assertEquals('version3', $post->latestVersion->contents['title']);
+    }
+
+    /**
+     * @test
+     */
+    public function user_cannot_create_versions_manually_without_changes()
+    {
+        $post = Post::create(['title' => 'version1', 'content' => 'version1 content']);
+
+        $this->assertCount(1, $post->refresh()->versions);
+        $this->assertEquals('version1', $post->latestVersion->contents['title']);
+
+        $this->assertNull($post->createVersion());
+        $this->assertNull($post->createVersion());
+        $this->assertNull($post->createVersion());
+
+        $this->assertCount(1, $post->refresh()->versions);
+    }
+
+    /**
+     * @test
+     */
+    public function user_cannot_create_versions_manually_by_passing_attributes()
+    {
+        $post = Post::create(['title' => 'version1', 'content' => 'version1 content']);
+        $post->setVersionStrategy(VersionStrategy::SNAPSHOT);
+
+        $this->assertCount(1, $post->refresh()->versions);
+        $this->assertEquals('version1', $post->latestVersion->contents['title']);
+
+        $this->assertNull($post->createVersion());
+
+        $this->assertNotNull($post->createVersion(['title' => 'version2']));
+        $this->assertCount(2, $post->refresh()->versions);
+        $this->assertEquals('version2', $post->latestVersion->contents['title']);
+
+        $this->assertNotNull($post->createVersion(['title' => 'version3']));
+        $this->assertCount(3, $post->refresh()->versions);
+        $this->assertEquals('version3', $post->latestVersion->contents['title']);
+    }
+
+    /**
+     * @test
+     */
+    public function user_can_create_versions_manually_if_versioning_is_disabled()
+    {
+        Post::disableVersioning();
+
+        $post = Post::create(['title' => 'version1', 'content' => 'version1 content']);
+
+        $this->assertCount(0, $post->refresh()->versions);
+
+        $post->update(['title' => 'version2']);
+
+        $this->assertCount(0, $post->refresh()->versions);
+
+        $this->assertNotNull($post->createVersion(['title' => 'version3']));
+        $this->assertCount(1, $post->refresh()->versions);
+        $this->assertEquals('version3', $post->latestVersion->contents['title']);
+    }
+
+    /**
+     * @test
+     */
+    public function attributes_will_be_merged_in_snapshot_mode()
+    {
+        Post::disableVersioning();
+
+        $post = Post::create(['title' => 'version1', 'content' => 'version1 content']);
+        $post->setVersionStrategy(VersionStrategy::DIFF);
+
+        $this->assertNotNull($post->createVersion(['title' => 'version3']));
+        $this->assertCount(1, $post->refresh()->versions);
+        $this->assertEquals(['title' => 'version3'], $post->latestVersion->contents);
+
+        $post->setVersionStrategy(VersionStrategy::SNAPSHOT);
+
+        $this->assertNotNull($post->createVersion(['title' => 'version4']));
+        $this->assertCount(2, $post->refresh()->versions);
+
+        $this->assertTrue(collect($post->latestVersion->contents)->has([
+            'id',
+            'title',
+            'content',
+            'extends',
+            'user_id',
+            'created_at',
+            'updated_at',
+        ]));
+
+        $this->assertCount(7, $post->latestVersion->contents);
+    }
+}


### PR DESCRIPTION
This introduces the possibility to add versions manually by using `createVersion()` on the versionable model. This is useful if one would like to tweak a models history later on and add historical data from the past.

```php
$post->createVersion(); // will do nothing if the model is not dirty

$post->title = 'Changed title';
$post->createVersion(); // will create a version even if versioning is disabled and the model changes are not stored (yet)

$post->createVersion(['title' => 'Changed title']); // will create a version of the model merged with the given attributes

$post->createVersion(['title' => 'very old version'], '1970-01-01') // allows to create historic versions
```

Because users are allowed to tweak a models version history later on the sorting has changed quite a bit. We are no longer sorting by `Version.id` alone. Instead `created_at` and `id` are taken into account to find previous and next versions.

And because `$model->versions` isn’t guaranteed to be sorted correctly anymore `$model->history` does exactly that:

```php
$post->versions;
// ['id' => 1, 'title' => 'First title', 'created_at' => '2022-10-07 12:15:00']
// ['id' => 2, 'title' => 'Changed title', 'created_at' => '2022-10-07 12:30:00']
// ['id' => 3, 'title' => 'very old version', 'created_at' => '1970-01-01 00:00:00']

$post->history;
// ['id' => 2, 'title' => 'Changed title', 'created_at' => '2022-10-07 12:30:00']
// ['id' => 1, 'title' => 'First title', 'created_at' => '2022-10-07 12:15:00']
// ['id' => 3, 'title' => 'very old version', 'created_at' => '1970-01-01 00:00:00']
```

Please check out the tests I've added which will give a good overview of the changes.