### PR TITLE
feat: Add support for nested arrays in content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
         "php": "^8.0.2",
         "laravel/framework": "^9.0|^10.0",
         "doctrine/dbal": "^3.0",
-        "jfcherng/php-diff": "^6.11"
+        "jfcherng/php-diff": "^6.11",
+        "rogervila/array-diff-multidimensional": "^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/src/Diff.php
+++ b/src/Diff.php
@@ -3,6 +3,7 @@
 namespace Overtrue\LaravelVersionable;
 
 use Jfcherng\Diff\DiffHelper;
+use Rogervila\ArrayDiffMultidimensional;
 
 /**
  * @see https://github.com/jfcherng/php-diff#example
@@ -81,7 +82,7 @@ class Diff
             }
         };
 
-        foreach (array_diff_assoc($fromContents, $toContents) as $key => $value) {
+        foreach (ArrayDiffMultidimensional::compare($fromContents, $toContents) as $key => $value) {
             $createDiff($key, $toContents[$key] ?? null, $value);
         }
 

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -130,4 +130,69 @@ class DiffTest extends TestCase
             (new Diff($new, $old))->toSideBySideHtml()
         );
     }
+
+    public function test_diff_nested_array_to_array()
+    {
+        $oldContent = [
+            'a' => 'nested content version 1',
+            'b' => [
+                -44.061269,
+                "lorem",
+                "ipsum dolor sit amet",
+            ],
+            'c' => [
+                'c1' => [
+                    'c11' => -44.061269,
+                    'c12' => 42.061269
+                ],
+                'c2' => "lorem",
+                'c3' => "ipsum dolor sit amet",
+            ]
+        ];
+        $old = new Version([
+            'contents' => [
+                'title' => 'version1',
+                'content' => $oldContent
+            ]
+        ]);
+
+        $newContent = [
+            'a' => 'nested content version 2',
+            'c' => [
+                'c1' => [
+                    'c11' => -46.061269,
+                    'c12' => 142.061269
+                ],
+                'c2' => "dolor",
+                'c3' => "sit amet",
+            ]
+        ];
+        $new = new Version([
+            'contents' => [
+                'title' => 'version2',
+                'content' => $newContent,
+                'user_id' => 123
+            ]
+        ]);
+
+        $this->assertSame(
+            [
+                'title' => [
+                    'old' => 'version1',
+                    'new' => 'version2'
+                ],
+                'content' => [
+                    'old' => $oldContent,
+                    'new' => $newContent
+                ],
+                'user_id' => [
+                    'old' => null,
+                    'new' => 123
+                ],
+            ],
+            (new Diff($new, $old))->toArray()
+        );
+
+
+    }
 }


### PR DESCRIPTION
When content is a nested array, `Diff::render()` method throws an `Array to string conversion` error.

This PR fixes it by replacing the call to `array_diff_assoc` with `Rogervila\ArrayDiffMultidimensional` (https://github.com/rogervila/array-diff-multidimensional) class that performs a nested diff.

Check the added `test_diff_nested_array_to_array` test in `DiffTest.php`.