### PR TITLE
fix: respect $dontVersionable when checking if version should be created

### DIFF
--- a/src/Versionable.php
+++ b/src/Versionable.php
@@ -223,7 +223,7 @@ trait Versionable
             return call_user_func([$this, 'shouldVersioning']);
         }
 
-        if ($this->versions()->count() === 0 || Arr::hasAny($this->getDirty(), $this->versionable)) {
+        if ($this->versions()->count() === 0 || Arr::hasAny($this->getDirty(), array_keys($this->getVersionableAttributes()))) {
             return true;
         }
 


### PR DESCRIPTION
PR #60 broke the usage of $dontVersionable.

This should respect `$versiobable` as well as `$dontVersionable`