### PR TITLE
Prevent lazyloading

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -36,6 +36,10 @@ class Version extends Model
         'contents' => 'json',
     ];
 
+    protected $with = [
+        'versionable',
+    ];
+
     protected static function booted()
     {
         static::creating(function (Version $version) {


### PR DESCRIPTION
If not set, the relationship is not lazyloaded and you can get errors like :
```
Attempted to lazy load [versionable] on model [Overtrue\LaravelVersionable\Version] but lazy loading is disabled.
```

if enforced.

This PR prevents that.