### PR TITLE
Fix diff statistics

### DIFF
--- a/src/Diff.php
+++ b/src/Diff.php
@@ -131,7 +131,16 @@ class Diff
         $diffStats = new Collection;
 
         foreach ($oldContents as $key => $value) {
-            if ($newContents[$key] !== $oldContents[$key]) {
+            if (! isset($newContents[$key])) {
+                $diffStats->push([
+                    'inserted' => is_string($oldContents[$key])
+                        ? substr_count($oldContents[$key], "\n") + 1
+                        : 1,
+                    'deleted' => 0,
+                    'unmodified' => 0,
+                    'changedRatio' => 1,
+                ]);
+            } else if ($newContents[$key] !== $oldContents[$key]) {
                 $diffStats->push(
                     (new Differ(
                         explode("\n", is_string($newContents[$key]) ? $newContents[$key] : json_encode($newContents[$key])),

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -213,6 +213,23 @@ class DiffTest extends TestCase
         $this->assertEquals(2, $stats['unmodified']); // two lines unmodified
     }
 
+    /**
+     * @test
+     */
+    public function it_can_return_correct_statistics_for_added_keys()
+    {
+        $old = new Version(['contents' => ['title' => 'example title']]);
+
+        // we are adding a new key with two lines
+        $new = new Version(['contents' => ['title' => 'example title', 'content' => "example content\n adding new line"]]);
+
+        $stats = (new Diff($new, $old))->getStatistics();
+
+        $this->assertEquals(2, $stats['inserted']); // two lines inserted
+        $this->assertEquals(0, $stats['deleted']); // no deletions
+        $this->assertEquals(0, $stats['unmodified']); // two lines unmodified
+    }
+
     public function test_diff_nested_array_to_array()
     {
         $oldContent = [


### PR DESCRIPTION
The `getStatistics` method throws an error when a new column is added to the model at a later point. This pull request should fix that.