### PR TITLE
Versionable::createInitialVersion fails if any global scope excludes …

### DIFF
--- a/src/Versionable.php
+++ b/src/Versionable.php
@@ -80,7 +80,7 @@ trait Versionable
     public function createInitialVersion(Model $model): Version
     {
         /** @var \Overtrue\LaravelVersionable\Versionable|Model $refreshedModel */
-        $refreshedModel = static::query()->findOrFail($model->getKey());
+        $refreshedModel = static::query()->withoutGlobalScopes()->findOrFail($model->getKey());
 
         /**
          * As initial version should include all $versionable fields,


### PR DESCRIPTION
…Model

Creating initial version fails when trying to query model from database if filtered by any global scope. Added withoutGlobalScopes() because versioning functionalities must be scope agnostic