### PR TITLE
Check if method isForceDeleting exists before calling it

### DIFF
--- a/src/Versionable.php
+++ b/src/Versionable.php
@@ -53,7 +53,7 @@ trait Versionable
         static::deleted(
             function (Model $model) {
                 /* @var \Overtrue\LaravelVersionable\Versionable|\Overtrue\LaravelVersionable\Version$model */
-                if ($model->isForceDeleting()) {
+                if (method_exists($model, 'isForceDeleting') && $model->isForceDeleting()) {
                     $model->forceRemoveAllVersions();
                 }
             }


### PR DESCRIPTION
For models that do not use the trait `SoftDeletes`, this call fails otherwise.