### PR TITLE
feat: Add support for other Foreign Key for different Models

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -87,13 +87,14 @@ class Version extends Model
         /* @var \Overtrue\LaravelVersionable\Versionable|Model $model */
         $versionClass = $model->getVersionModel();
         $versionConnection = $model->getConnectionName();
+        $userForeignKeyName = $model->getUserForeignKeyName();
 
         $version = new $versionClass();
         $version->setConnection($versionConnection);
 
         $version->versionable_id = $model->getKey();
         $version->versionable_type = $model->getMorphClass();
-        $version->{config('versionable.user_foreign_key')} = $model->getVersionUserId();
+        $version->{$userForeignKeyName} = $model->getVersionUserId();
         $version->contents = $model->getVersionableAttributes($replacements);
 
         if ($time) {

--- a/src/Versionable.php
+++ b/src/Versionable.php
@@ -24,6 +24,7 @@ trait Versionable
     // You can define this variable in class, that used this trait to change Model(table) for versions
     // Model MUST extend \Overtrue\LaravelVersionable\Version
     //public string $versionModel;
+    //public string $userForeignKeyName;
 
     public static function bootVersionable(): void
     {
@@ -319,9 +320,14 @@ trait Versionable
         return $this->versionModel ?? config('versionable.version_model');
     }
 
+    public function getUserForeignKeyName(): string
+    {
+        return $this->userForeignKeyName ?? config('versionable.user_foreign_key');
+    }
+
     public function getVersionUserId()
     {
-        return auth()->id() ?? $this->getAttribute(\config('versionable.user_foreign_key'));
+        return $this->getAttribute($this->getUserForeignKeyName()) ?? auth()->id();
     }
 
     public function getKeepVersionsCount(): string


### PR DESCRIPTION
You must first create a model with such a foreign key instead of default user_id

e.g
```php
public string $versionModel = OffersVersions::class;
public string $userForeignKeyName = 'token_id';
```