### PR TITLE
Add an option uuid_version_id

### DIFF
--- a/config/versionable.php
+++ b/config/versionable.php
@@ -23,7 +23,12 @@ return [
     'user_model' => \App\Models\User::class,
 
     /**
-     * Use uuid for version id.
+     * Use uuid for version id and primary key.
      */
-    'uuid' => false,
+    'uuid' => false, // This must be false if 'uuid_version_id' is set to true
+
+    /**
+     * Use uuid only for version id.
+     */
+    'uuid_version_id' => false,
 ];

--- a/migrations/2019_05_31_042934_create_versions_table.php
+++ b/migrations/2019_05_31_042934_create_versions_table.php
@@ -13,11 +13,12 @@ return new class() extends Migration
     {
         Schema::create('versions', function (Blueprint $table) {
             $uuid = config('versionable.uuid');
+            $uuidVersionId = config('versionable.uuid_version_id', false);
 
             $uuid ? $table->uuid('id')->primary() : $table->bigIncrements('id');
             $table->unsignedBigInteger(config('versionable.user_foreign_key', 'user_id'));
 
-            $uuid ? $table->uuidMorphs('versionable') : $table->morphs('versionable');
+            $uuid || $uuidVersionId ? $table->uuidMorphs('versionable') : $table->morphs('versionable');
 
             $table->json('contents')->nullable();
             $table->timestamps();


### PR DESCRIPTION
Add an option uuid_version_id to set only the version_id in a Model as UUID and leave the primary key as an auto-increment integer. 