### PR TITLE
Resolution for Issue #89

### DIFF
--- a/src/Versionable.php
+++ b/src/Versionable.php
@@ -145,7 +145,7 @@ trait Versionable
             ->first();
     }
 
-    public function getVersion(int $id): ?Version
+    public function getVersion(int|string $id): ?Version
     {
         return $this->versions()->find($id);
     }
@@ -163,12 +163,12 @@ trait Versionable
         return $this->versions()->onlyTrashed()->get();
     }
 
-    public function restoreTrashedVersion(int $id)
+    public function restoreTrashedVersion(int|string $id)
     {
         return $this->versions()->onlyTrashed()->whereId($id)->restore();
     }
 
-    public function revertToVersion(int $id): bool
+    public function revertToVersion(int|string $id): bool
     {
         return $this->versions()->findOrFail($id)->revert();
     }
@@ -191,7 +191,7 @@ trait Versionable
         return $this->versions()->findMany($ids)->each->delete();
     }
 
-    public function removeVersion(int $id)
+    public function removeVersion(int|string $id)
     {
         if ($this->forceDeleteVersion) {
             return $this->forceRemoveVersion($id);
@@ -209,7 +209,7 @@ trait Versionable
         $this->versions->each->delete();
     }
 
-    public function forceRemoveVersion(int $id)
+    public function forceRemoveVersion(int|string $id)
     {
         return $this->versions()->findOrFail($id)->forceDelete();
     }

--- a/tests/VersionWithUuidTest.php
+++ b/tests/VersionWithUuidTest.php
@@ -33,4 +33,119 @@ class VersionWithUuidTest extends TestCase
 
         $this->assertIsString($version->id);
     }
+
+    public function testUuidGetVersion()
+    {
+        $user = User::create(['name' => 'overtrue']);
+        $this->actingAs($user);
+
+        $post = Post::create(['title' => 'Hello world!', 'content' => 'Hello world!']);
+        $original_version = $post->versions()->first();
+
+        //Confirms we are using UUID
+        $this->assertIsString($original_version->id);
+
+        //Breaks in v5.3.2 and earlier.
+        $version = $post->getVersion($original_version->id);
+
+        $this->assertEquals($original_version->id, $version->id);
+    }
+
+    public function testUuidRestoreToVersion()
+    {
+        $user = User::create(['name' => 'overtrue']);
+        $this->actingAs($user);
+
+        $post = Post::create(['title' => 'Hello world!', 'content' => 'Hello world!']);
+        $original_version = $post->versions()->first();
+
+        //Confirms we are using UUID
+        $this->assertIsString($original_version->id);
+
+        //Update the Title to get a new version
+        $post->update(['title' => 'A New World!']);
+
+        $this->assertCount(2, $post->refresh()->versions);
+
+        $new_version = $post->latestVersion;
+        $this->assertNotEquals($new_version->id, $original_version->id);
+
+        //Breaks with v5.3.2
+        $post->revertToVersion($original_version->id);
+
+        $this->assertCount(3, $post->refresh()->versions);
+        $this->assertEquals('Hello world!', $post->title);
+    }
+
+    public function testUuidRemoveVersion()
+    {
+        $user = User::create(['name' => 'overtrue']);
+        $this->actingAs($user);
+
+        $post = Post::create(['title' => 'Hello world!', 'content' => 'Hello world!']);
+        $original_version = $post->versions()->first();
+
+        //Confirms we are using UUID
+        $this->assertIsString($original_version->id);
+
+        //Update the Title to get a new version
+        $post->update(['title' => 'A New World!']);
+
+        $this->assertCount(2, $post->refresh()->versions);
+
+        //Breaks in v5.3.2 and earlier.
+        $post->removeVersion($original_version->id);
+
+        $this->assertCount(1, $post->refresh()->versions);
+
+    }
+
+    public function testUuidForceRemoveVersion()
+    {
+        $user = User::create(['name' => 'overtrue']);
+        $this->actingAs($user);
+
+        $post = Post::create(['title' => 'Hello world!', 'content' => 'Hello world!']);
+        $original_version = $post->versions()->first();
+
+        //Confirms we are using UUID
+        $this->assertIsString($original_version->id);
+
+        //Update the Title to get a new version
+        $post->update(['title' => 'A New World!']);
+
+        $this->assertCount(2, $post->refresh()->versions);
+
+        //Breaks in v5.3.2 and earlier.
+        $post->forceRemoveVersion($original_version->id);
+
+        $this->assertCount(1, $post->refresh()->versions);
+    }
+
+    public function testUuidRestoreTrashedVersion()
+    {
+        $user = User::create(['name' => 'overtrue']);
+        $this->actingAs($user);
+
+        $post = Post::create(['title' => 'Hello world!', 'content' => 'Hello world!']);
+        $original_version = $post->versions()->first();
+
+        //Confirms we are using UUID
+        $this->assertIsString($original_version->id);
+
+        //Update the Title to get a new version
+        $post->update(['title' => 'A New World!']);
+
+        $this->assertCount(2, $post->refresh()->versions);
+
+        //Breaks in v5.3.2 and earlier.
+        $post->removeVersion($original_version->id);
+
+        $this->assertCount(1, $post->refresh()->versions);
+
+        //Breaks in v5.3.2 and earlier.
+        $post->restoreTrashedVersion($original_version->id);
+
+        $this->assertCount(2, $post->refresh()->versions);
+    }
 }


### PR DESCRIPTION
- Add more tests to the `VersionWithUuidTests.php` that fail with the original version(v5.3.2).
- Update `Versionable` trait accept either an `int` or `string` for functions that need the `id` of the underlying Versionable, supporting configurations that use UUID in place of the integer based ID's.